### PR TITLE
fix: frame-data truncation (H4) and selection growth (H5) in animation loading

### DIFF
--- a/src/main/java/com/ivan1pl/animations/data/MCMEStoragePlotFrame.java
+++ b/src/main/java/com/ivan1pl/animations/data/MCMEStoragePlotFrame.java
@@ -178,15 +178,8 @@ public class MCMEStoragePlotFrame implements IFrame, IStoragePlot {
     }
 
     public void load(File file) {
-        try (BufferedInputStream in = new BufferedInputStream(new GZIPInputStream(new FileInputStream(file)));
-                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            byte[] buffer = new byte[1024];
-            int readBytes;
-            do {
-                readBytes = in.read(buffer, 0, buffer.length);
-                out.write(buffer, 0, readBytes);
-            } while (readBytes == buffer.length);
-            frameNBTData = out.toByteArray();
+        try (BufferedInputStream in = new BufferedInputStream(new GZIPInputStream(new FileInputStream(file)))) {
+            frameNBTData = in.readAllBytes();
         } catch (IOException ex) {
             Logger.getLogger(MCMEStoragePlotFrame.class.getName()).log(Level.SEVERE, null, ex);
         }

--- a/src/main/java/com/ivan1pl/animations/data/MovingAnimation.java
+++ b/src/main/java/com/ivan1pl/animations/data/MovingAnimation.java
@@ -193,7 +193,7 @@ public class MovingAnimation extends Animation {
         animation.setStepZ(config.getInt("StepZ", 0));
         animation.setMaxDistance(config.getInt("MaxDistance", 0));
         animation.frame = MCMEStoragePlotFrame.fromSelection(animation.getSelection(), true);
-        Selection backgroundSelection = animation.selection;
+        Selection backgroundSelection = SerializationUtils.clone(animation.selection);
         backgroundSelection.expand(
                 animation.stepX * animation.getFrameCount(),
                 animation.stepY * animation.getFrameCount(),


### PR DESCRIPTION
Two data-integrity fixes in the animation load paths, found during an audit of the deployed v1.4 jar. Both bugs predate the Brigadier work and survive on every branch, so this is stacked on top of `feat/brigadier` (targets it as base; flows into `development` via #14).

## H4 — frame data read to EOF instead of a length-guarded loop
`MCMEStoragePlotFrame.load()` read the gzip stream with:
```java
do { n = in.read(buf); out.write(buf, 0, n); } while (n == buf.length);
```
On a `GZIPInputStream` this has two failure modes:
- `read()` may return **fewer** bytes than requested mid-stream, ending the loop early and **silently truncating** `frameNBTData` — a corrupt paste, or an `InvalidRestoreDataException` swallowed later at `show()`.
- at EOF `read()` returns `-1`, so `out.write(buf, 0, -1)` throws `IndexOutOfBoundsException`, which is **not** an `IOException` and escapes `prepare()` → `reloadAnimation()` → `onEnable()`.

Replaced with `frameNBTData = in.readAllBytes();`, which reads to true EOF in one call. No behavioural change on well-formed frames; every `.mcme` frame loads through this path.

## H5 — clone the selection before expanding it in `MovingAnimation.load()`
`load()` aliased the animation's own selection and then `expand()`ed it in place:
```java
Selection backgroundSelection = animation.selection;
backgroundSelection.expand(step * frameCount, ...);
```
`Selection.expand()` mutates in place, so this grew the persisted selection on every load, wrote the enlarged bounds back on the next save, and crept upward each load/save cycle until `maxProcessedBlocks` refused to start the animation. It also left `getSelection()` returning the expanded (wrong) bounds.

`updateBackground()` already does this correctly with `SerializationUtils.clone(selection)` — this mirrors that in `load()`.

## Verification
- Full `gradle compileJava` passes against paper-api 1.21.4 + PluginUtils 1.9.1.
- No automated tests exist in the repo, so these are inspection- + compile-verified only. **Remaining check:** a smoke test loading one stationary and one moving animation on a dev server (confirm frames paste fully and the moving selection doesn't creep across reloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
