### PR TITLE
test: regression tests + CI for frame loading (H4/H5), fixing an AnimationsLocation Serializable regression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,25 @@ repositories {
 dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
     implementation 'com.mcmiddleearth:PluginUtils:1.9.1'
+
+    testImplementation platform('org.junit:junit-bom:6.0.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Paper API is needed on the test classpath for the org.bukkit types the data classes
+    // reference; the tests exercise pure logic and never start a server. (A MockBukkit
+    // server was tried but cannot construct the plot-storage frames: PluginUtils reads
+    // Chunk#getTileEntities, which MockBukkit leaves unimplemented.)
+    testImplementation 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
+}
+
+// PluginUtils pulls in dynmap-api, which drags the ancient org.bukkit:bukkit:1.7.10.
+// On the test classpath that collides with paper-api's bukkit capability, so drop the
+// legacy jar here (paper-api provides a superset of the org.bukkit API).
+configurations.testCompileClasspath {
+    exclude group: 'org.bukkit', module: 'bukkit'
+}
+configurations.testRuntimeClasspath {
+    exclude group: 'org.bukkit', module: 'bukkit'
 }
 
 // https://docs.gradle.org/current/dsl/org.gradle.api.plugins.JavaPluginExtension.html
@@ -46,6 +65,10 @@ jar {
 
 shadowJar {
     archiveClassifier = "" // Removes -all from the end of the generated JAR
+}
+
+test {
+    useJUnitPlatform()
 }
 
 tasks {

--- a/src/main/java/com/ivan1pl/animations/data/AnimationsLocation.java
+++ b/src/main/java/com/ivan1pl/animations/data/AnimationsLocation.java
@@ -18,6 +18,7 @@
  */
 package com.ivan1pl.animations.data;
 
+import java.io.Serializable;
 import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -28,7 +29,12 @@ import org.bukkit.configuration.ConfigurationSection;
  *
  * @author Ivan1pl, Eriol_Eandur
  */
-public class AnimationsLocation {
+public class AnimationsLocation implements Serializable {
+
+    // Selection is deep-copied via Java serialization (SerializationUtils.clone), and it holds
+    // AnimationsLocation instances, so this must stay Serializable even though the legacy .anim
+    // format that first required it has been removed.
+    private static final long serialVersionUID = 5482328410797364959L;
 
     private double x;
     private double y;

--- a/src/main/java/com/ivan1pl/animations/data/MovingAnimation.java
+++ b/src/main/java/com/ivan1pl/animations/data/MovingAnimation.java
@@ -193,12 +193,21 @@ public class MovingAnimation extends Animation {
         animation.setStepZ(config.getInt("StepZ", 0));
         animation.setMaxDistance(config.getInt("MaxDistance", 0));
         animation.frame = MCMEStoragePlotFrame.fromSelection(animation.getSelection(), true);
-        Selection backgroundSelection = SerializationUtils.clone(animation.selection);
-        backgroundSelection.expand(
-                animation.stepX * animation.getFrameCount(),
-                animation.stepY * animation.getFrameCount(),
-                animation.stepZ * animation.getFrameCount());
+        Selection backgroundSelection = expandedBackgroundSelection(
+                animation.selection, animation.stepX, animation.stepY, animation.stepZ, animation.getFrameCount());
         animation.background = MCMEStoragePlotFrame.fromSelection(backgroundSelection, true);
         return animation;
+    }
+
+    /**
+     * Builds the (larger) background selection from the frame selection. The frame selection
+     * must be left untouched: {@link Selection#expand} mutates in place, so this clones first.
+     * Aliasing the stored selection here used to grow it by {@code step * frameCount} on every
+     * load/save cycle (audit finding H5).
+     */
+    static Selection expandedBackgroundSelection(Selection selection, int stepX, int stepY, int stepZ, int frameCount) {
+        Selection expanded = SerializationUtils.clone(selection);
+        expanded.expand(stepX * frameCount, stepY * frameCount, stepZ * frameCount);
+        return expanded;
     }
 }

--- a/src/test/java/com/ivan1pl/animations/data/MCMEStoragePlotFrameLoadTest.java
+++ b/src/test/java/com/ivan1pl/animations/data/MCMEStoragePlotFrameLoadTest.java
@@ -1,0 +1,63 @@
+package com.ivan1pl.animations.data;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression test for the frame data read path (audit finding H4).
+ *
+ * <p>{@code load(File)} previously read the gzip stream with a length-guarded loop
+ * ({@code do { n = in.read(buf); ... } while (n == buf.length)}). Because
+ * {@link java.util.zip.GZIPInputStream} hands back data in chunks smaller than a
+ * 1&nbsp;KiB request, that loop ended after the first short read (silently truncating
+ * the frame) or, at EOF, called {@code write(buf, 0, -1)} and threw. The sizes below
+ * straddle that boundary so a round-trip catches both failure modes.
+ */
+class MCMEStoragePlotFrameLoadTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadReturnsExactlyWhatSaveWrote() throws Exception {
+        for (int size : new int[] {0, 100, 512, 1024, 5000, 70000}) {
+            byte[] original = pattern(size);
+            File file = tempDir.resolve("frame_" + size + ".mcme").toFile();
+
+            MCMEStoragePlotFrame saver = new MCMEStoragePlotFrame();
+            setFrameNbtData(saver, original);
+            saver.save(file);
+
+            MCMEStoragePlotFrame loader = new MCMEStoragePlotFrame();
+            loader.load(file);
+
+            assertArrayEquals(
+                    original, getFrameNbtData(loader), "round-trip must preserve every byte for payload size " + size);
+        }
+    }
+
+    private static byte[] pattern(int size) {
+        byte[] data = new byte[size];
+        for (int i = 0; i < size; i++) {
+            data[i] = (byte) ((i * 31 + 7) & 0xFF);
+        }
+        return data;
+    }
+
+    private static void setFrameNbtData(MCMEStoragePlotFrame frame, byte[] data) throws Exception {
+        Field field = MCMEStoragePlotFrame.class.getDeclaredField("frameNBTData");
+        field.setAccessible(true);
+        field.set(frame, data);
+    }
+
+    private static byte[] getFrameNbtData(MCMEStoragePlotFrame frame) throws Exception {
+        Field field = MCMEStoragePlotFrame.class.getDeclaredField("frameNBTData");
+        field.setAccessible(true);
+        return (byte[]) field.get(frame);
+    }
+}

--- a/src/test/java/com/ivan1pl/animations/data/MovingAnimationTest.java
+++ b/src/test/java/com/ivan1pl/animations/data/MovingAnimationTest.java
@@ -1,0 +1,42 @@
+package com.ivan1pl.animations.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.bukkit.Location;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the background-selection logic of {@link MovingAnimation#load} (audit
+ * finding H5).
+ *
+ * <p>The full {@code load(ConfigurationSection)} path cannot be exercised in a unit test: it
+ * builds plot-storage frames through PluginUtils, which reads {@code Chunk#getTileEntities} and
+ * so needs a real server. The clone-before-expand behaviour that the fix restored is therefore
+ * factored into {@link MovingAnimation#expandedBackgroundSelection}, which is pure and tested
+ * here directly.
+ */
+class MovingAnimationTest {
+
+    @Test
+    void expandedBackgroundSelectionLeavesTheFrameSelectionUntouched() {
+        Selection frame = selection(0, 0, 0, 4, 4, 4);
+
+        // stepX * frameCount = 1 * 10 = 10
+        Selection background = MovingAnimation.expandedBackgroundSelection(frame, 1, 0, 0, 10);
+
+        // Before the fix, load() aliased and expanded the stored selection in place, so it grew
+        // by step * frameCount every load/save cycle. The frame selection must stay put.
+        assertEquals(4, frame.getPoint2().getBlockX(), "frame selection must not be mutated (H5)");
+        assertEquals(
+                14,
+                background.getPoint2().getBlockX(),
+                "background must be the frame selection expanded by step * frameCount");
+    }
+
+    private static Selection selection(int x1, int y1, int z1, int x2, int y2, int z2) {
+        Selection selection = new Selection();
+        selection.setPoint1(new Location(null, x1, y1, z1));
+        selection.setPoint2(new Location(null, x2, y2, z2));
+        return selection;
+    }
+}


### PR DESCRIPTION
Adds a JUnit test harness, CI, and regression tests for the two frame-loading fixes — and, in the process, uncovers and fixes a **runtime regression already on this branch**.

Stacked on `feat/brigadier` (targets it; reaches `development` via #14).

## 🐛 Fix: `AnimationsLocation` lost `Serializable` (this branch NPEs today)

`d025c5a` ("deleted legacy .anim format") removed `implements Serializable` from the data classes. That's correct for the ones only used by the `.anim` format — but `Selection` is **still** `Serializable` and is still deep-copied with `SerializationUtils.clone` (in `MovingAnimation.updateBackground()` and in `load()`), and `Selection` holds `AnimationsLocation`.

With `AnimationsLocation` no longer serializable, that clone throws `NotSerializableException`, which `SerializationUtils.clone` swallows and returns `null` — so **`MovingAnimation.load()` NPEs, i.e. loading any moving animation crashes on `feat/brigadier` today.** The H5 fix merged in #15 can't actually run without this.

Fix: restore `implements Serializable` + the original `serialVersionUID` on `AnimationsLocation` only.

## ✅ Regression tests (both verified to fail without their fix)

- **`MCMEStoragePlotFrameLoadTest`** (H4) — round-trips frame data at sizes that straddle `GZIPInputStream`'s internal chunk boundary; fails on the old length-guarded read loop.
- **`MovingAnimationTest`** (H5) — asserts the frame selection isn't mutated when the background is built; fails both on the aliasing bug *and* on a non-serializable `AnimationsLocation`.

Each was confirmed RED by reverting the relevant fix, then GREEN with it in place.

## 🔧 Testability refactor

`MovingAnimation.load()` can't be unit-tested end-to-end: it builds plot-storage frames through PluginUtils, which reads `Chunk#getTileEntities`. A real server is required, and **MockBukkit leaves that unimplemented** (and maps it to a JUnit *skip*, so a MockBukkit test silently passes without running). The clone-before-expand logic is therefore extracted into a pure `MovingAnimation.expandedBackgroundSelection(...)` and tested directly. Behaviour unchanged.

## ⚙️ CI — deferred (PluginUtils blocker)

A GitHub Actions workflow was attempted but **cannot pass yet**: PluginUtils 1.9.1 isn't on any public Maven repo, and its `pom.xml` compiles against a paperclip-patched server jar via a hard-coded local `systemPath`, so it can't be built on a clean runner (and papermc's v2 download API is now deprecated). CI needs **PluginUtils published to a resolvable Maven repo** (e.g. GitHub Packages) first — then the workflow is ~3 lines. The best-effort workflow is kept out-of-repo for later.

## Verified locally
`./gradlew build` green (compile, both tests, spotless, shadowJar). Not covered: a live server smoke test of the animations themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
