### PR TITLE
fix: persist /anim sound remove; stop shading PluginUtils into the jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,11 @@ repositories {
 
 dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
-    implementation 'com.mcmiddleearth:PluginUtils:1.9.1'
+    // Provided at runtime by the separate PluginUtils plugin (see softdepend in plugin.yml),
+    // so it must NOT be shaded in. compileOnly keeps PluginUtils — and its transitive dynmap-api
+    // plus ~5 MB of stale org.bukkit 1.7.10 classes — out of the shadowJar. The pre-Gradle jar
+    // never bundled PluginUtils either.
+    compileOnly 'com.mcmiddleearth:PluginUtils:1.9.1'
 
     testImplementation platform('org.junit:junit-bom:6.0.3')
     testImplementation 'org.junit.jupiter:junit-jupiter'
@@ -29,6 +33,9 @@ dependencies {
     // server was tried but cannot construct the plot-storage frames: PluginUtils reads
     // Chunk#getTileEntities, which MockBukkit leaves unimplemented.)
     testImplementation 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
+    // PluginUtils is compileOnly for the main source (not shaded); the tests still compile
+    // against MCMEStoragePlotFrame (implements IStoragePlot), so it needs to be here too.
+    testImplementation 'com.mcmiddleearth:PluginUtils:1.9.1'
 }
 
 // PluginUtils pulls in dynmap-api, which drags the ancient org.bukkit:bukkit:1.7.10.

--- a/src/main/java/com/ivan1pl/animations/commands/AnimSoundCommand.java
+++ b/src/main/java/com/ivan1pl/animations/commands/AnimSoundCommand.java
@@ -89,7 +89,9 @@ public class AnimSoundCommand {
 
     private static LiteralArgumentBuilder<CommandSourceStack> removeSubcommand() {
         return Commands.literal("remove").executes(ctx -> {
-            AnimationArgumentType.getAnimation(ctx, "name").setSoundData(null);
+            Animation animation = AnimationArgumentType.getAnimation(ctx, "name");
+            animation.setSoundData(null);
+            Animations.saveAnimation(animation.getName());
             MessageUtil.sendInfoMessage(ctx.getSource().getSender(), Messages.MSG_SOUND_REMOVE_SUCCESS);
             return Command.SINGLE_SUCCESS;
         });


### PR DESCRIPTION
Two fixes from the review of #14 (the third finding — the `Animations` → `MCME-Animations` data-folder relocation — is intentional and will be handled by the planned config/data-format migration, so it's not touched here).

## 1. `/anim sound <name> remove` now persists
The `remove` handler mutated `setSoundData(null)` in memory but never saved, while `set` calls `Animations.saveAnimation(...)`. As one-shot Brigadier commands there's no trailing save, so a removed sound came back on the next reload/restart. Now it persists immediately, mirroring `executeSet`.

## 2. Stop shading PluginUtils into the jar
PluginUtils was `implementation`, so `shadowJar` bundled it + transitive dynmap-api + **~5 MB of stale `org.bukkit` 1.7.10 classes** into the shipped jar (and would trip Paper's "plugin bundles Bukkit" warning). PluginUtils is provided at runtime by the separate PluginUtils plugin (`softdepend`), and the pre-Gradle jar never bundled it — so `compileOnly`. Added as `testImplementation` so the tests still compile.

**Result:** shipped `MCME-Animations-1.5.jar` goes from ~5 MB → **127 KB**, containing only the plugin's own 99 classes.

## Verified
`./gradlew build` green — compile, both regression tests, palantir format, shadowJar. Confirmed the shipped jar contains **0** `com/mcmiddleearth/pluginutil`, **0** `org/bukkit`, **0** `org/dynmap` classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)