### PR TITLE
build: migrate Animations to Paper 26.2 / Java 25 / PluginUtils 2.0.1 (JitPack)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     // Provided at runtime by the separate PluginUtils plugin (see depend in plugin.yml), so it
     // must NOT be shaded in — compileOnly keeps it out of the shadowJar. Resolved from JitPack
     // (com.github.MCME:PluginUtils), which ends the "install PluginUtils to mavenLocal first" step.
-    compileOnly 'com.github.MCME:PluginUtils:2.0.1'
+    compileOnly 'com.github.MCME:PluginUtils:2.0.2'
 
     testImplementation platform('org.junit:junit-bom:6.0.3')
     testImplementation 'org.junit.jupiter:junit-jupiter'
@@ -35,7 +35,7 @@ dependencies {
     testImplementation 'io.papermc.paper:paper-api:26.2.build.111-stable'
     // PluginUtils is compileOnly for the main source (not shaded); the tests still compile
     // against MCMEStoragePlotFrame (implements IStoragePlot), so it needs to be here too.
-    testImplementation 'com.github.MCME:PluginUtils:2.0.1'
+    testImplementation 'com.github.MCME:PluginUtils:2.0.2'
 }
 
 // PluginUtils pulls in dynmap-api, which drags the ancient org.bukkit:bukkit:1.7.10.

--- a/build.gradle
+++ b/build.gradle
@@ -15,15 +15,15 @@ repositories {
     }
     mavenLocal()
     mavenCentral()
+    maven { url = "https://jitpack.io" }
 }
 
 dependencies {
-    compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
-    // Provided at runtime by the separate PluginUtils plugin (see softdepend in plugin.yml),
-    // so it must NOT be shaded in. compileOnly keeps PluginUtils — and its transitive dynmap-api
-    // plus ~5 MB of stale org.bukkit 1.7.10 classes — out of the shadowJar. The pre-Gradle jar
-    // never bundled PluginUtils either.
-    compileOnly 'com.mcmiddleearth:PluginUtils:1.9.1'
+    compileOnly 'io.papermc.paper:paper-api:26.2.build.111-stable'
+    // Provided at runtime by the separate PluginUtils plugin (see depend in plugin.yml), so it
+    // must NOT be shaded in — compileOnly keeps it out of the shadowJar. Resolved from JitPack
+    // (com.github.MCME:PluginUtils), which ends the "install PluginUtils to mavenLocal first" step.
+    compileOnly 'com.github.MCME:PluginUtils:2.0.1'
 
     testImplementation platform('org.junit:junit-bom:6.0.3')
     testImplementation 'org.junit.jupiter:junit-jupiter'
@@ -32,10 +32,10 @@ dependencies {
     // reference; the tests exercise pure logic and never start a server. (A MockBukkit
     // server was tried but cannot construct the plot-storage frames: PluginUtils reads
     // Chunk#getTileEntities, which MockBukkit leaves unimplemented.)
-    testImplementation 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
+    testImplementation 'io.papermc.paper:paper-api:26.2.build.111-stable'
     // PluginUtils is compileOnly for the main source (not shaded); the tests still compile
     // against MCMEStoragePlotFrame (implements IStoragePlot), so it needs to be here too.
-    testImplementation 'com.mcmiddleearth:PluginUtils:1.9.1'
+    testImplementation 'com.github.MCME:PluginUtils:2.0.1'
 }
 
 // PluginUtils pulls in dynmap-api, which drags the ancient org.bukkit:bukkit:1.7.10.
@@ -49,7 +49,7 @@ configurations.testRuntimeClasspath {
 }
 
 // https://docs.gradle.org/current/dsl/org.gradle.api.plugins.JavaPluginExtension.html
-def targetJavaVersion = 21
+def targetJavaVersion = 25
 java {
     toolchain {
         // Intellij should pick this up
@@ -80,7 +80,7 @@ test {
 
 tasks {
     runServer {
-        minecraftVersion("1.21.4")
+        minecraftVersion("26.2")
     }
 }
 


### PR DESCRIPTION
Modernizes Animations to the 26.2 line.

## Changes (build only — no code changes needed)
- `paper-api` `1.21.4-R0.1-SNAPSHOT` → **`26.2.build.111-stable`** (matches the production server)
- Java toolchain `21` → **`25`**
- PluginUtils `com.mcmiddleearth:PluginUtils:1.9.1` (mavenLocal) → **`com.github.MCME:PluginUtils:2.0.1`** via JitPack (adds the `jitpack.io` repo) — no more "install PluginUtils to mavenLocal first"
- run-paper → `26.2`

## Why no code changes
Animations uses almost entirely stable Bukkit API. Compiling against 26.2 surfaced **zero** errors: `Biome.PLAINS` and the `String` `playSound` overload still resolve, the one `Sound.valueOf` reference was already dead-commented, and Drayz's sound command already uses the modern `Registry.SOUNDS`.

## Verified
`./gradlew build` green on JDK 25 — compile, **both regression tests** (H4/H5, now running against paper-api 26.2 + PluginUtils 2.0.1), palantir format, and shadowJar. Output jar is Java 25 (major 69), correct for a Paper 26.2 server.

## Data note (unchanged by this PR)
The animation data format (`animation.yml` + `.mcme`) is unchanged, so existing production data loads as-is. The one deployment step is the folder rename that came with the earlier `Animations` → `MCME-Animations` plugin rename: `plugins/Animations/` → `plugins/MCME-Animations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)